### PR TITLE
Fix Disabled Basic Actions removing Condensed Class Actions

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -477,12 +477,25 @@ export function initConfig() {
 
                 const showSpecialActions = game.settings.get(MODULE_ID, "showSpecialActions");
 
-                const buttons = [new DND5eItemButton({ item: null, isWeaponSet: true, isPrimary: true }), new ARGON.MAIN.BUTTONS.SplitButton(new DND5eSpecialActionButton(specialActions[0]), new DND5eSpecialActionButton(specialActions[1])), ...spellButton, new DND5eButtonPanelButton({ type: "feat", items: featItems, color: 0 }), new ARGON.MAIN.BUTTONS.SplitButton(new DND5eSpecialActionButton(specialActions[2]), new DND5eSpecialActionButton(specialActions[3])), new ARGON.MAIN.BUTTONS.SplitButton(new DND5eSpecialActionButton(specialActions[4]), new DND5eSpecialActionButton(specialActions[5])), new DND5eButtonPanelButton({ type: "consumable", items: consumableItems, color: 0 })];
+                const buttons = showSpecialActions ? [
+                    new DND5eItemButton({ item: null, isWeaponSet: true, isPrimary: true }),
+                    new ARGON.MAIN.BUTTONS.SplitButton(new DND5eSpecialActionButton(specialActions[0]), new DND5eSpecialActionButton(specialActions[1])),
+                    ...spellButton,
+                    new DND5eButtonPanelButton({ type: "feat", items: featItems, color: 0 }),
+                    new ARGON.MAIN.BUTTONS.SplitButton(new DND5eSpecialActionButton(specialActions[2]), new DND5eSpecialActionButton(specialActions[3])),
+                    new ARGON.MAIN.BUTTONS.SplitButton(new DND5eSpecialActionButton(specialActions[4]), new DND5eSpecialActionButton(specialActions[5])),
+                    new DND5eButtonPanelButton({ type: "consumable", items: consumableItems, color: 0 })
+                ] : [
+                    new DND5eItemButton({ item: null, isWeaponSet: true, isPrimary: true }),
+                    ...spellButton,
+                    new DND5eButtonPanelButton({ type: "feat", items: featItems, color: 0 }),
+                    new DND5eButtonPanelButton({ type: "consumable", items: consumableItems, color: 0 })
+                ];
 
                 const barItems = this.actor.items.filter((item) => CoreHUD.DND5E.mainBarFeatures.includes(item.system.type?.value) && actionTypes.action.includes(item.system.activation?.type));
                 buttons.push(...condenseItemButtons(barItems));
                 
-                return buttons.filter((button) => button.hasContents || button.items == undefined || button.items.length).filter((button) => showSpecialActions || !(button instanceof ARGON.MAIN.BUTTONS.SplitButton));
+                return buttons.filter((button) => button.hasContents || button.items == undefined || button.items.length);
             }
         }
 


### PR DESCRIPTION
So, here's a bug: disabling basic actions also disables (removes completely) condensed class actions. After trying to get it worked for some time, I decided to check out the logic in place.

And here it was. `condensedItemButtons` func produces SplitButton class instances, which are instantly filtered out by showSpecialActions filter. I fixed it in the most direct approach to just not create special actions when they're not needed. Writing the equivalent thing inside the webpack'ed module showed this fix to solve the problem for me.

I hope you don't mind it's a PR not a full-fledged issue with all the details about my setup.